### PR TITLE
recompressed lists.txt, modified run_all script so it won't delete archive

### DIFF
--- a/2_integer_codes/code/README.md
+++ b/2_integer_codes/code/README.md
@@ -18,14 +18,14 @@ To compile for maximum speed, disable all asserts (`-DNDEBUG`) and also use the 
 	
 Now, first unzip the file `lists.txt.gz` which contains 10 sorted integer lists:
 
-	gunzip lists.txt.gz
+	gunzip -k lists.txt.gz
 
 Then use the program `./compress` to actually compress the lists.
 The program expects the following arguments:
 
 	Usage: ./compress [type] [input_lists_filename] [output_filename]
 
-where `type` is one of the following: `gamma`, `delta`, `vbyte`, `rice_k1`, or `rice_k2`.	
+where `type` is one of the following: `gamma`, `delta`, `vbyte`, `rice_k1`, or `rice_k2`.
 
 Below, some examples with type `gamma`.
 

--- a/2_integer_codes/code/run_all.sh
+++ b/2_integer_codes/code/run_all.sh
@@ -1,4 +1,6 @@
-gunzip lists.txt.gz
+#!/bin/sh
+
+gzip -dc lists.txt.gz > lists.txt
 
 # g++ -std=c++11 -DDEBUG compress.cpp -o compress
 # g++ -std=c++11 -DDEBUG decompress.cpp -o decompress
@@ -33,4 +35,4 @@ rm out_rice_k2.bin
 ./decompress vbyte out_vbyte.bin
 rm out_vbyte.bin
 
-gzip lists.txt
+rm lists.txt

--- a/3_list_compressors/code/README.md
+++ b/3_list_compressors/code/README.md
@@ -23,7 +23,7 @@ To compile for maximum speed, disable all asserts (`-DNDEBUG`) and also use the 
     
 Now, first unzip the file `lists.txt.gz` in the folder `2_integer_codes/code` which contains 10 sorted integer lists:
 
-    gunzip ../../2_integer_codes/code/lists.txt.gz
+    gunzip -k ../../2_integer_codes/code/lists.txt.gz
 
 Then use the program `./compress` to actually compress the lists.
 The program expects the following arguments:

--- a/3_list_compressors/code/run_all.sh
+++ b/3_list_compressors/code/run_all.sh
@@ -1,4 +1,6 @@
-gunzip ../../2_integer_codes/code/lists.txt.gz
+#!/bin/sh
+
+gunzip -k ../../2_integer_codes/code/lists.txt.gz
 
 # g++ -std=c++11 -DDEBUG compress.cpp -o compress
 # g++ -std=c++11 -DDEBUG -mbmi2 -msse4.2 decompress.cpp -o decompress
@@ -18,4 +20,4 @@ rm out_ef.bin
 ./decompress bic out_bic.bin
 rm out_bic.bin
 
-gzip ../../2_integer_codes/code/lists.txt
+rm ../../2_integer_codes/code/lists.txt


### PR DESCRIPTION
As befits a decent repository about compression I recompressed \`lists.txt', cutting in half its size, and modified running scripts so it won't delete it. There is no point in decompressing and compressing it all over again every single time one runs a test.

It might be a good idea to make a script to generate this list if there is some logic behind these numbers.
